### PR TITLE
Update Dockerfile

### DIFF
--- a/torchserve/Dockerfile
+++ b/torchserve/Dockerfile
@@ -3,6 +3,7 @@
 FROM continuumio/miniconda3
 
 # install os dependencies
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \


### PR DESCRIPTION
Jre installation requires the man folder to exist on the server,In the newer JDK, an issue will be reported where the folder/usr/share/man/man1 does not exist